### PR TITLE
Fix paths

### DIFF
--- a/1_fetch/sb_get.py
+++ b/1_fetch/sb_get.py
@@ -44,4 +44,4 @@ def main(sb_item, sb_file):
 if __name__ == "__main__":
     sb_item = "5e5d0bb9e4b01d50924f2b36"
     sb_file = "1_fetch/out/pgdl_predictions_04_N45.50-48.00_W92.00-93.00.zip"
-    main(sb_item, sb_file, out_dir)
+    main(sb_item, sb_file)

--- a/1_fetch/sb_get.py
+++ b/1_fetch/sb_get.py
@@ -43,5 +43,5 @@ def main(sb_item, sb_file):
 
 if __name__ == "__main__":
     sb_item = "5e5d0bb9e4b01d50924f2b36"
-    sb_file = "1_fetch/out/pgdl_predictions_04_N45.50-48.00_W92.00-93.00.zip"
+    sb_file = "1_fetch/tmp/pgdl_predictions_04_N45.50-48.00_W92.00-93.00.zip"
     main(sb_item, sb_file)

--- a/2_process/calc_doy_means.py
+++ b/2_process/calc_doy_means.py
@@ -26,5 +26,5 @@ if __name__ == '__main__':
     lake_ids = ["120020150", "107072210"]
     for lake_id in lake_ids:
         out_file = f"2_process/out/doy_{lake_id}.csv"
-        in_file = f"1_fetch/out/tmp/pgdl_nhdhr_{lake_id}_temperatures.csv"
+        in_file = f"1_fetch/out/pgdl/pgdl_nhdhr_{lake_id}_temperatures.csv"
         main(out_file, in_file, lake_id)

--- a/2_process/combine_site_files.py
+++ b/2_process/combine_site_files.py
@@ -15,8 +15,6 @@ def main(out_file, site_files):
     combine_site_files(site_files, out_file)
 
 if __name__ == '__main__':
-    out_dir = os.path.join("2_process", "out")
-    out_file = os.path.join(out_dir, "combined_doy.csv")
-    lake_ids = ["120020150", "107072210"]
-    site_files = [os.path.join(out_dir, f"doy_{i}.csv") for i in lake_ids]
+    out_file = "2_process/out/combined_doy.csv"
+    site_files = ["2_process/out/doy_107072210.csv", "2_process/out/doy_120020150.csv"]
     main(out_file, site_files)


### PR DESCRIPTION
This PR contains fixes I discovered when trying to run the scripts without Snakemake, as they are. 

1. A call to `main()` in `sb_get.py` had too many arguments
2. Incorrect paths for zip files and unzipped files
3. The code in `combine_site_files.py` under `if __name__ == '__main__':` was overengineered, obfuscating the code's purpose.